### PR TITLE
Allow to download to input directory if specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "container-image-artifact",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Node module containing functionalities for upload/downloading container images as artifact in github action",
   "main": "./src/index.js",
   "scripts": {

--- a/src/image_artifact.js
+++ b/src/image_artifact.js
@@ -50,12 +50,13 @@ exports.getUploader = function (artifactUploader, containerEngineName = "docker"
  * 
  * For a github artifact to be linked with the given image name, it has to be named in predictable way.
  * Eg. image `foo:latest` packaged as `foo_latest` uploaded as an artifact named `image_artifact_foo_latest`
- *      can be downloaded and loaded with ${downloadDir}/${packageName} i.e /tmp/foo_latest
+ *      can be downloaded and loaded with ${downloadTmpDir}/${packageName}
+ *      i.e /tmp/foo_latest, ${{ runner.temp }}/foo_tag ...
  */
 exports.getDownloader = function (artifactDownloader, containerEngineName = "docker") {
     const containerEngine = getContainerEngine(containerEngineName);
-    return async (image) => {
-        const downloadDir = await artifactDownloader(resolveArtifactName(image), os.tmpdir());
+    return async (image, downloadTmpDir = os.tmpdir() ) => {
+        const downloadDir = await artifactDownloader(resolveArtifactName(image), downloadTmpDir);
 
         const imagePackagePath = path.join(downloadDir, resolvePackageName(image));
         await containerEngine.loadImage(imagePackagePath);


### PR DESCRIPTION
Backward behaviour is preserved if not input is provided, it will use OS's tmp dir.

The motivation is to harden the action, to prevent injection, if attacker is granted to write in /tmp,
the typical use case is to restrict to runner temporary dir.

This change has been tested using an other change in related downloader action.

Relate-to: https://github.com/ishworkh/container-image-artifact-download/issues/7#issuecomment-2904751460